### PR TITLE
Ver5 improvements

### DIFF
--- a/Client.java
+++ b/Client.java
@@ -1,56 +1,151 @@
 import java.io.*;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
 
 public class Client {
     private static final String LOAD_BALANCER_ADDRESS = "localhost";
     private static final int LOAD_BALANCER_PORT = 11114;
+
     private static DatagramSocket udpSocket;
     private static volatile boolean keepListening = true;
 
     public static void main(String[] args) {
+        Thread udpListenerThread = null;
         try {
+            // UDP socket for streaming (ephemeral local port)
             udpSocket = new DatagramSocket();
-            Thread udpListenerThread = new Thread(Client::listenForUDP);
+            udpListenerThread = new Thread(Client::listenForUDP, "Client-UDP");
             udpListenerThread.start();
 
-            try (Socket lbSocket = new Socket(LOAD_BALANCER_ADDRESS, LOAD_BALANCER_PORT);
-                 BufferedReader lbIn = new BufferedReader(new InputStreamReader(lbSocket.getInputStream()));
-                 PrintWriter lbOut = new PrintWriter(lbSocket.getOutputStream(), true)) {
-
-                String serverAddress = lbIn.readLine().replace("/", "").trim();
-                System.out.println("Directed to connect to server at: " + serverAddress);
-
-                String[] addressParts = serverAddress.split(":");
-                try (Socket serverSocket = new Socket(addressParts[0], Integer.parseInt(addressParts[1]));
-                     BufferedReader serverIn = new BufferedReader(new InputStreamReader(serverSocket.getInputStream()));
-                     PrintWriter serverOut = new PrintWriter(serverSocket.getOutputStream(), true);
-                     BufferedReader userIn = new BufferedReader(new InputStreamReader(System.in))) {
-
-                    String userInput;
-                    while (true) {
-                        if (userIn.ready()) {
-                            userInput = userIn.readLine();
-                            serverOut.println(userInput);
-                            if ("quit".equalsIgnoreCase(userInput)) {
-                                keepListening = false;
-                                break;
-                            }
-                        }
-
-                        if (serverIn.ready()) {
-                            System.out.println("Server says: " + serverIn.readLine());
-                        }
-                    }
+            // Parse args
+            String clientName = null;
+            String mode = "static";
+            for (int i = 0; i < args.length; i++) {
+                String a = args[i];
+                if (("--name".equalsIgnoreCase(a) || "-n".equalsIgnoreCase(a)) && i + 1 < args.length) {
+                    clientName = args[++i];
+                } else if (("--mode".equalsIgnoreCase(a) || "-m".equalsIgnoreCase(a)) && i + 1 < args.length) {
+                    mode = args[++i].toLowerCase();
                 }
             }
-            udpListenerThread.join();
+            if (clientName == null || clientName.trim().isEmpty()) {
+                clientName = "Client-" + UUID.randomUUID().toString().substring(0, 8);
+            }
+            if (!"dynamic".equalsIgnoreCase(mode)) {
+                mode = "static";
+            }
+            System.out.println("Client name: " + clientName + ", mode: " + mode);
+
+            // Ask the load balancer for a server
+            String serverAddress;
+            try (Socket lbSocket = new Socket(LOAD_BALANCER_ADDRESS, LOAD_BALANCER_PORT);
+                 BufferedReader lbIn = new BufferedReader(new InputStreamReader(lbSocket.getInputStream(), StandardCharsets.UTF_8));
+                 PrintWriter lbOut = new PrintWriter(new OutputStreamWriter(lbSocket.getOutputStream(), StandardCharsets.UTF_8), true)) {
+
+                lbOut.println("HELLO " + clientName + " " + mode);
+                serverAddress = lbIn.readLine();
+            }
+
+            if (serverAddress == null) throw new IOException("No response from load balancer");
+            serverAddress = serverAddress.replace("/", "").trim();
+            if ("NO_SERVER_AVAILABLE".equalsIgnoreCase(serverAddress)) {
+                System.out.println("No server available. Exiting.");
+                keepListening = false;
+                return;
+            }
+            System.out.println("Directed to server at: " + serverAddress);
+
+            String[] addressParts = serverAddress.split(":");
+            String serverHost = addressParts[0];
+            int serverPort = Integer.parseInt(addressParts[1]);
+
+            // Connect to the server
+            try (Socket serverSocket = new Socket(serverHost, serverPort);
+                 BufferedReader serverIn = new BufferedReader(new InputStreamReader(serverSocket.getInputStream(), StandardCharsets.UTF_8));
+                 PrintWriter serverOut = new PrintWriter(new OutputStreamWriter(serverSocket.getOutputStream(), StandardCharsets.UTF_8), true);
+                 BufferedReader userIn = new BufferedReader(new InputStreamReader(System.in))) {
+
+                // Identify and register UDP port
+                System.out.println("Identifying to server as: " + clientName);
+                serverOut.println("hello " + clientName);
+                int udpPort = udpSocket.getLocalPort();
+                serverOut.println("udp " + udpPort);
+
+                while (true) {
+                    // Send user commands if available
+                    if (userIn.ready()) {
+                        String userInput = userIn.readLine();
+                        if (userInput == null) break;
+                        serverOut.println(userInput);
+                        if ("quit".equalsIgnoreCase(userInput.trim())) {
+                            keepListening = false;
+                            break;
+                        }
+                    }
+
+                    // Read server messages if available
+                    if (serverIn.ready()) {
+                        String line = serverIn.readLine();
+                        if (line == null) break;
+
+                        if (line.startsWith("FILE ")) {
+                            receiveFile(line, serverIn);
+                        } else {
+                            System.out.println("Server says: " + line);
+                        }
+                    }
+
+                    // light sleep to avoid busy spin if neither side is ready
+                    try { Thread.sleep(10); } catch (InterruptedException ignored) {}
+                }
+            }
+
         } catch (Exception e) {
             System.out.println("Error: " + e.getMessage());
         } finally {
+            keepListening = false;
             if (udpSocket != null && !udpSocket.isClosed()) {
                 udpSocket.close();
             }
+            if (udpListenerThread != null) {
+                try { udpListenerThread.join(); } catch (InterruptedException ignored) {}
+            }
+        }
+    }
+
+    // Receive Base64-encoded file until ENDFILE
+    private static void receiveFile(String header, BufferedReader serverIn) throws IOException {
+        // Header format: "FILE <name> <sizeBytes>"
+        String[] parts = header.trim().split("\\s+");
+        if (parts.length < 3) {
+            System.out.println("Malformed FILE header: " + header);
+            return;
+        }
+        String name = parts[1];
+        long size = -1L;
+        try { size = Long.parseLong(parts[2]); } catch (NumberFormatException ignore) {}
+
+        String outName = "received_" + name;
+        try (FileOutputStream fos = new FileOutputStream(outName)) {
+            Base64.Decoder dec = Base64.getDecoder();
+            long written = 0;
+            while (true) {
+                String b64 = serverIn.readLine();
+                if (b64 == null) {
+                    System.out.println("Unexpected end of stream during file transfer.");
+                    break;
+                }
+                if ("ENDFILE".equals(b64)) break;
+                byte[] chunk = dec.decode(b64);
+                fos.write(chunk);
+                written += chunk.length;
+            }
+            fos.flush();
+            System.out.println("File received: " + outName + " (" + written + " bytes" + (size >= 0 ? " / expected " + size : "") + ")");
+        } catch (IOException e) {
+            System.out.println("File receive error: " + e.getMessage());
         }
     }
 
@@ -63,8 +158,10 @@ public class Client {
                 String received = new String(packet.getData(), 0, packet.getLength(), StandardCharsets.UTF_8);
                 System.out.println("Received UDP packet: " + received);
             }
+        } catch (SocketException se) {
+            // closed during shutdown
         } catch (IOException e) {
-            System.out.println("UDP socket closed or error: " + e.getMessage());
+            System.out.println("UDP listener error: " + e.getMessage());
         }
     }
 }

--- a/LoadBalancer.java
+++ b/LoadBalancer.java
@@ -1,71 +1,175 @@
-import java.io.*;
-import java.net.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class LoadBalancer {
-    private static final int CLIENT_PORT = 11114;  // Port to handle client requests
-    private static final int REGISTRATION_PORT = 11115;  // Port to accept server registrations
+    private static final int CLIENT_PORT = 11114;         // Port to handle client requests
+    private static final int REGISTRATION_PORT = 11115;   // Port to accept server registrations
+
     private ServerSocket clientSocket;
     private ServerSocket registrationSocket;
+
     private final List<ServerInfo> servers = Collections.synchronizedList(new ArrayList<>());
     private final AtomicInteger roundRobinIndex = new AtomicInteger(0);
+    private final AtomicInteger clientIdCounter = new AtomicInteger(1);
+
+    // Dynamic mode support: cache RTTs from background pings
+    private final ConcurrentMap<ServerInfo, Long> rtts = new ConcurrentHashMap<>();
+    private ScheduledExecutorService rttScheduler;
 
     public LoadBalancer() throws IOException {
         clientSocket = new ServerSocket(CLIENT_PORT);
         registrationSocket = new ServerSocket(REGISTRATION_PORT);
-        System.out.println("Load Balancer running on ports " + CLIENT_PORT + " and " + REGISTRATION_PORT);
+        System.out.println("Load Balancer running on ports " + CLIENT_PORT + " (clients) and " + REGISTRATION_PORT + " (registrations)");
+        startRttRefresher();
     }
 
     public void start() {
-        new Thread(this::handleServerRegistrations).start();
-        new Thread(this::handleClientRequests).start();
+        new Thread(this::handleServerRegistrations, "LB-Registration").start();
+        new Thread(this::handleClientRequests, "LB-Clients").start();
     }
 
     private void handleServerRegistrations() {
-        try {
-            while (true) {
-                Socket serverSocket = registrationSocket.accept();
-                BufferedReader in = new BufferedReader(new InputStreamReader(serverSocket.getInputStream()));
-                PrintWriter out = new PrintWriter(serverSocket.getOutputStream(), true);
-                String registrationMessage = in.readLine();
-                if (registrationMessage != null && registrationMessage.startsWith("!join")) {
-                    String[] parts = registrationMessage.split(" ");
-                    int port = Integer.parseInt(parts[3]);  // Correct index to parse the port number
-                    servers.add(new ServerInfo(serverSocket.getInetAddress().getHostAddress(), port));
+        while (true) {
+            try (Socket s = registrationSocket.accept();
+                 BufferedReader in = new BufferedReader(new InputStreamReader(s.getInputStream()));
+                 PrintWriter out = new PrintWriter(s.getOutputStream(), true)) {
+
+                String msg = in.readLine();
+                if (msg != null && msg.startsWith("!join")) {
+                    String[] parts = msg.trim().split("\\s+");
+                    // last token is the port (supports "!join -v dynamic 11112" or similar)
+                    int port = Integer.parseInt(parts[parts.length - 1]);
+                    ServerInfo info = new ServerInfo(s.getInetAddress().getHostAddress(), port);
+                    synchronized (servers) {
+                        if (!servers.contains(info)) {
+                            servers.add(info);
+                            System.out.println("Registered server: " + info);
+                        } else {
+                            System.out.println("Server already registered: " + info);
+                        }
+                    }
                     out.println("!ack");
-                    System.out.println("Registered server: " + serverSocket.getInetAddress().getHostAddress() + ":" + port);
+                } else {
+                    out.println("!err");
                 }
-                serverSocket.close();
+            } catch (Exception e) {
+                System.out.println("Registration handling error: " + e.getMessage());
             }
-        } catch (IOException e) {
-            System.out.println("Error handling server registrations: " + e.getMessage());
         }
     }
 
     private void handleClientRequests() {
-        try {
-            while (true) {
-                Socket client = clientSocket.accept();
-                ServerInfo server = selectServer();
-                if (server != null) {
-                    PrintWriter out = new PrintWriter(client.getOutputStream(), true);
-                    out.println(server.address + ":" + server.port);
-                    client.close();
-                    System.out.println("Client directed to: " + server.address + ":" + server.port);
+        while (true) {
+            try (Socket client = clientSocket.accept()) {
+                String clientName = null;
+                String mode = "static"; // default
+
+                client.setSoTimeout(1000);
+                BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
+                PrintWriter out = new PrintWriter(client.getOutputStream(), true);
+
+                String line = null;
+                try {
+                    line = in.readLine();
+                } catch (IOException ignore) { /* timeout or no hello */ }
+
+                if (line != null && line.toUpperCase().startsWith("HELLO")) {
+                    String[] parts = line.trim().split("\\s+");
+                    if (parts.length >= 2) clientName = parts[1];
+                    if (parts.length >= 3) mode = parts[2].toLowerCase(Locale.ROOT);
                 }
+                if (clientName == null || clientName.isEmpty()) {
+                    clientName = "Client-" + clientIdCounter.getAndIncrement();
+                }
+
+                ServerInfo server = "dynamic".equalsIgnoreCase(mode) ? selectServerDynamic() : selectServerStatic();
+                if (server != null) {
+                    out.println(server.address + ":" + server.port);
+                    System.out.println("Client '" + clientName + "' (" + mode + ") -> " + server);
+                } else {
+                    out.println("NO_SERVER_AVAILABLE");
+                    System.out.println("No server available for client '" + clientName + "'");
+                }
+            } catch (Exception ex) {
+                System.out.println("Error processing client: " + ex.getMessage());
             }
-        } catch (IOException e) {
-            System.out.println("Error handling client requests: " + e.getMessage());
         }
     }
 
-    private ServerInfo selectServer() {
-        if (servers.isEmpty()) {
-            System.out.println("No servers are currently registered.");
-            return null;
+    private ServerInfo selectServerStatic() {
+        synchronized (servers) {
+            int n = servers.size();
+            if (n == 0) {
+                System.out.println("No servers are currently registered.");
+                return null;
+            }
+            int idx = Math.floorMod(roundRobinIndex.getAndIncrement(), n);
+            return servers.get(idx);
         }
-        return servers.get(roundRobinIndex.getAndIncrement() % servers.size());
+    }
+
+    private ServerInfo selectServerDynamic() {
+        ServerInfo best = null;
+        long bestT = Long.MAX_VALUE;
+        synchronized (servers) {
+            if (servers.isEmpty()) {
+                System.out.println("No servers are currently registered.");
+                return null;
+            }
+            for (ServerInfo s : servers) {
+                Long t = rtts.get(s);
+                if (t != null && t < bestT) {
+                    bestT = t;
+                    best = s;
+                }
+            }
+        }
+        return best != null ? best : selectServerStatic();
+    }
+
+    private void startRttRefresher() {
+        rttScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "LB-RTT-Refresher");
+            t.setDaemon(true);
+            return t;
+        });
+        rttScheduler.scheduleAtFixedRate(() -> {
+            List<ServerInfo> snapshot;
+            synchronized (servers) {
+                snapshot = new ArrayList<>(servers);
+            }
+            snapshot.parallelStream().forEach(s -> {
+                long t = pingServer(s, 300);
+                if (t >= 0) {
+                    rtts.put(s, t);
+                }
+            });
+        }, 0, 1, TimeUnit.SECONDS);
+    }
+
+    private long pingServer(ServerInfo s, int timeoutMs) {
+        try (Socket sock = new Socket()) {
+            sock.connect(new InetSocketAddress(s.address, s.port), timeoutMs);
+            sock.setSoTimeout(timeoutMs);
+            PrintWriter out = new PrintWriter(sock.getOutputStream(), true);
+            BufferedReader in = new BufferedReader(new InputStreamReader(sock.getInputStream()));
+            long start = System.nanoTime();
+            out.println("ping");
+            String resp = in.readLine();
+            long end = System.nanoTime();
+            if (resp != null && resp.trim().equalsIgnoreCase("pong")) {
+                return (end - start) / 1_000_000; // ms
+            }
+        } catch (IOException ignored) {}
+        return -1;
     }
 
     public static void main(String[] args) {
@@ -78,12 +182,20 @@ public class LoadBalancer {
     }
 
     static class ServerInfo {
-        String address;
-        int port;
+        final String address;
+        final int port;
 
         ServerInfo(String addr, int port) {
             this.address = addr;
             this.port = port;
         }
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ServerInfo)) return false;
+            ServerInfo that = (ServerInfo) o;
+            return port == that.port && Objects.equals(address, that.address);
+        }
+        @Override public int hashCode() { return Objects.hash(address, port); }
+        @Override public String toString() { return address + ":" + port; }
     }
 }

--- a/LoadBalancer.java
+++ b/LoadBalancer.java
@@ -5,154 +5,427 @@ import java.io.PrintWriter;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class LoadBalancer {
-    private static final int CLIENT_PORT = 11114;         // Port to handle client requests
-    private static final int REGISTRATION_PORT = 11115;   // Port to accept server registrations
+    private static final int CLIENT_PORT = 11114;         // client handshakes
+    private static final int REGISTRATION_PORT = 11115;   // server join + reports
 
     private ServerSocket clientSocket;
     private ServerSocket registrationSocket;
 
+    // Registered servers (by value object)
     private final List<ServerInfo> servers = Collections.synchronizedList(new ArrayList<>());
-    private final AtomicInteger roundRobinIndex = new AtomicInteger(0);
-    private final AtomicInteger clientIdCounter = new AtomicInteger(1);
 
-    // Dynamic mode support: cache RTTs from background pings
+    // Weighted RR support
+    private final ConcurrentMap<ServerInfo, Integer> weights = new ConcurrentHashMap<>();
+    private volatile List<ServerInfo> weightedList = new CopyOnWriteArrayList<>();
+    private final AtomicInteger rrIndex = new AtomicInteger(0);
+
+    // Dynamic mode RTT cache
     private final ConcurrentMap<ServerInfo, Long> rtts = new ConcurrentHashMap<>();
     private ScheduledExecutorService rttScheduler;
+    private volatile int pingIntervalMs = 1000;
+
+    // Assignment bookkeeping (best-effort)
+    private final ConcurrentMap<ServerInfo, CopyOnWriteArrayList<ClientRecord>> assignedByServer = new ConcurrentHashMap<>();
+    private final Deque<ClientRecord> recentAssignments = new ConcurrentLinkedDeque<>();
+    private static final int MAX_RECENT = 500;
+
+    // Live client reports from servers
+    private final ConcurrentMap<ServerInfo, CopyOnWriteArrayList<LiveClient>> liveByServer = new ConcurrentHashMap<>();
+
+    // Drain / limits / bans
+    private final Set<ServerInfo> drained = ConcurrentHashMap.newKeySet();
+    private volatile int maxPerServer = Integer.MAX_VALUE;        // enforce using live reports
+    private final Set<String> bannedIps = ConcurrentHashMap.newKeySet();
+    private final Set<String> bannedNames = ConcurrentHashMap.newKeySet();
+
+    // Default mode when client omits it
+    private volatile String defaultMode = "static";
+
+    private final AtomicInteger clientIdCounter = new AtomicInteger(1);
+
+    private static final DateTimeFormatter TS_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withZone(ZoneId.systemDefault());
 
     public LoadBalancer() throws IOException {
         clientSocket = new ServerSocket(CLIENT_PORT);
         registrationSocket = new ServerSocket(REGISTRATION_PORT);
-        System.out.println("Load Balancer running on ports " + CLIENT_PORT + " (clients) and " + REGISTRATION_PORT + " (registrations)");
+        System.out.println("Load Balancer on " + CLIENT_PORT + " (clients), " + REGISTRATION_PORT + " (servers)");
         startRttRefresher();
     }
 
     public void start() {
-        new Thread(this::handleServerRegistrations, "LB-Registration").start();
+        new Thread(this::handleServerChannel, "LB-ServerChannel").start();
         new Thread(this::handleClientRequests, "LB-Clients").start();
+        new Thread(this::adminConsole, "LB-Console").start();
     }
 
-    private void handleServerRegistrations() {
+    // =================== Admin Console ===================
+    private void adminConsole() {
+        System.out.println("Admin console ready. Type 'help'.");
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                String[] parts = line.trim().split("\\s+");
+                if (parts.length == 0 || parts[0].isEmpty()) continue;
+                String cmd = parts[0].toLowerCase(Locale.ROOT);
+
+                try {
+                    switch (cmd) {
+                        case "servers": printServers(); break;
+                        case "clients": printAssigned(); break;
+                        case "live": printLive(); break;
+                        case "status":
+                            printServers();
+                            printLive();
+                            break;
+                        case "recent": printRecent(); break;
+
+                        case "drained": printDrained(); break;
+                        case "drain":
+                            if (parts.length == 2 && "all".equalsIgnoreCase(parts[1])) drainAll();
+                            else if (parts.length == 2) drain(parseServer(parts[1]));
+                            else System.out.println("Usage: drain <host:port|all>");
+                            break;
+                        case "undrain":
+                            if (parts.length == 2 && "all".equalsIgnoreCase(parts[1])) undrainAll();
+                            else if (parts.length == 2) undrain(parseServer(parts[1]));
+                            else System.out.println("Usage: undrain <host:port|all>");
+                            break;
+
+                        case "setweight":
+                            if (parts.length != 3) { System.out.println("Usage: setweight <host:port> <N>"); break; }
+                            setWeight(parseServer(parts[1]), Integer.parseInt(parts[2]));
+                            break;
+                        case "weights": printWeights(); break;
+
+                        case "mode":
+                            if (parts.length == 3 && "default".equalsIgnoreCase(parts[1])) {
+                                if (!"static".equalsIgnoreCase(parts[2]) && !"dynamic".equalsIgnoreCase(parts[2])) {
+                                    System.out.println("Value must be static|dynamic");
+                                } else {
+                                    defaultMode = parts[2].toLowerCase(Locale.ROOT);
+                                    System.out.println("Default mode set to " + defaultMode);
+                                }
+                            } else {
+                                System.out.println("Usage: mode default <static|dynamic>");
+                            }
+                            break;
+
+                        case "set":
+                            if (parts.length == 3 && "ping".equalsIgnoreCase(parts[1])) {
+                                int ms = Integer.parseInt(parts[2]);
+                                setPingInterval(ms);
+                                System.out.println("RTT ping interval set to " + ms + "ms");
+                            } else if (parts.length == 3 && "maxconn".equalsIgnoreCase(parts[1])) {
+                                maxPerServer = Integer.parseInt(parts[2]);
+                                System.out.println("Max live clients per server set to " + maxPerServer);
+                            } else {
+                                System.out.println("Usage: set ping <ms> | set maxconn <N>");
+                            }
+                            break;
+
+                        case "ban":
+                            if (parts.length == 3 && "ip".equalsIgnoreCase(parts[1])) {
+                                bannedIps.add(parts[2]); System.out.println("Banned IP " + parts[2]);
+                            } else if (parts.length == 3 && "name".equalsIgnoreCase(parts[1])) {
+                                bannedNames.add(parts[2]); System.out.println("Banned name " + parts[2]);
+                            } else System.out.println("Usage: ban ip <x> | ban name <x>");
+                            break;
+                        case "unban":
+                            if (parts.length == 3 && "ip".equalsIgnoreCase(parts[1])) {
+                                bannedIps.remove(parts[2]); System.out.println("Unbanned IP " + parts[2]);
+                            } else if (parts.length == 3 && "name".equalsIgnoreCase(parts[1])) {
+                                bannedNames.remove(parts[2]); System.out.println("Unbanned name " + parts[2]);
+                            } else System.out.println("Usage: unban ip <x> | unban name <x>");
+                            break;
+                        case "bans":
+                            System.out.println("Banned IPs: " + bannedIps);
+                            System.out.println("Banned names: " + bannedNames);
+                            break;
+
+                        case "remove":
+                            if (parts.length != 2) { System.out.println("Usage: remove <host:port>"); break; }
+                            removeServer(parseServer(parts[1]));
+                            break;
+
+                        case "clear":
+                            assignedByServer.clear();
+                            recentAssignments.clear();
+                            System.out.println("Cleared assignment history.");
+                            break;
+
+                        case "help":
+                            System.out.println("Commands:\n" +
+                                    "  servers          - list servers (rtt, weight, drain, live)\n" +
+                                    "  live             - show live clients per server (reported)\n" +
+                                    "  clients          - show recent LB assignments\n" +
+                                    "  status           - servers + live\n" +
+                                    "  recent           - last " + MAX_RECENT + " assignments\n" +
+                                    "  drain <hp|all>   - mark server(s) unschedulable\n" +
+                                    "  undrain <hp|all> - make schedulable again\n" +
+                                    "  drained          - list drained servers\n" +
+                                    "  setweight <hp> <N> | weights\n" +
+                                    "  mode default <static|dynamic>\n" +
+                                    "  set ping <ms> | set maxconn <N>\n" +
+                                    "  ban ip <x> | ban name <x> | unban ip/name <x> | bans\n" +
+                                    "  remove <host:port>\n" +
+                                    "  clear | help");
+                            break;
+                        default:
+                            System.out.println("Unknown command. Type 'help'.");
+                    }
+                } catch (Exception ex) {
+                    System.out.println("Error: " + ex.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            System.out.println("Console error: " + e.getMessage());
+        }
+    }
+
+    private void printServers() {
+        System.out.println("\n== SERVERS ==");
+        List<ServerInfo> snapshot;
+        synchronized (servers) { snapshot = new ArrayList<>(servers); }
+        if (snapshot.isEmpty()) { System.out.println("(none)"); return; }
+        snapshot.sort(Comparator.comparing((ServerInfo s) -> s.address).thenComparingInt(s -> s.port));
+        for (ServerInfo s : snapshot) {
+            Long rtt = rtts.get(s);
+            int live = liveByServer.getOrDefault(s, new CopyOnWriteArrayList<>()).size();
+            Integer w = weights.getOrDefault(s, 1);
+            String flags = (drained.contains(s) ? " drained" : "");
+            System.out.printf("- %s:%d  rtt=%s  weight=%d  live=%d%s%n",
+                    s.address, s.port, (rtt == null ? "n/a" : (rtt + "ms")), w, live, flags);
+        }
+    }
+
+    private void printAssigned() {
+        System.out.println("\n== RECENT ASSIGNMENTS (by LB) ==");
+        if (recentAssignments.isEmpty()) { System.out.println("(none)"); return; }
+        recentAssignments.stream().limit(100)
+                .forEach(cr -> System.out.printf("%s  client=%s  mode=%s  -> %s:%d  from=%s%n",
+                        TS_FMT.format(Instant.ofEpochMilli(cr.assignedAt)), cr.clientName, cr.mode, cr.server.address, cr.server.port, cr.lbSeenRemote));
+    }
+
+    private void printRecent() { printAssigned(); }
+
+    private void printLive() {
+        System.out.println("\n== LIVE CLIENTS (reported by servers) ==");
+        List<ServerInfo> snapshot;
+        synchronized (servers) { snapshot = new ArrayList<>(servers); }
+        if (snapshot.isEmpty()) { System.out.println("(no servers)"); return; }
+        snapshot.sort(Comparator.comparing((ServerInfo s) -> s.address).thenComparingInt(s -> s.port));
+        for (ServerInfo s : snapshot) {
+            List<LiveClient> list = liveByServer.getOrDefault(s, new CopyOnWriteArrayList<>());
+            System.out.printf("%s:%d  (%d clients)%n", s.address, s.port, list.size());
+            for (LiveClient lc : list) {
+                System.out.printf("  • %s  ip=%s  at=%s%n", lc.name, lc.ip, TS_FMT.format(Instant.ofEpochMilli(lc.reportedAt)));
+            }
+        }
+        System.out.println();
+    }
+
+    private void printWeights() {
+        System.out.println("\n== WEIGHTS ==");
+        if (weights.isEmpty()) { System.out.println("(all weight=1)"); return; }
+        weights.forEach((s,w) -> System.out.println(s + " -> " + w));
+    }
+
+    private void printDrained() {
+        System.out.println("\n== DRAINED SERVERS ==");
+        if (drained.isEmpty()) { System.out.println("(none)"); return; }
+        drained.forEach(s -> System.out.println("- " + s));
+    }
+
+    // =================== Server channel ===================
+    private void handleServerChannel() {
         while (true) {
             try (Socket s = registrationSocket.accept();
                  BufferedReader in = new BufferedReader(new InputStreamReader(s.getInputStream()));
                  PrintWriter out = new PrintWriter(s.getOutputStream(), true)) {
 
                 String msg = in.readLine();
-                if (msg != null && msg.startsWith("!join")) {
+                if (msg == null) continue;
+
+                if (msg.startsWith("!join")) {
+                    // "!join ... <port>"
                     String[] parts = msg.trim().split("\\s+");
-                    // last token is the port (supports "!join -v dynamic 11112" or similar)
                     int port = Integer.parseInt(parts[parts.length - 1]);
                     ServerInfo info = new ServerInfo(s.getInetAddress().getHostAddress(), port);
                     synchronized (servers) {
                         if (!servers.contains(info)) {
                             servers.add(info);
+                            weights.putIfAbsent(info, 1);
+                            rebuildWeighted();
                             System.out.println("Registered server: " + info);
                         } else {
                             System.out.println("Server already registered: " + info);
                         }
                     }
                     out.println("!ack");
+                } else if (msg.startsWith("!report")) {
+                    // "!report <port> clients <n> <name>@<ip> ..."
+                    try { handleReport(s.getInetAddress().getHostAddress(), msg); }
+                    catch (Exception ex) { System.out.println("Bad report: " + ex.getMessage()); }
+                    // no response needed
                 } else {
                     out.println("!err");
                 }
             } catch (Exception e) {
-                System.out.println("Registration handling error: " + e.getMessage());
+                System.out.println("Registration channel error: " + e.getMessage());
             }
         }
     }
 
+    private void handleReport(String srcIp, String line) {
+        String[] p = line.trim().split("\\s+");
+        if (p.length < 4 || !p[2].equalsIgnoreCase("clients")) return;
+        int tcpPort = Integer.parseInt(p[1]);
+        int n = Integer.parseInt(p[3]);
+
+        ServerInfo key = new ServerInfo(srcIp, tcpPort);
+        List<LiveClient> list = new ArrayList<>();
+        for (int i = 0; i < n && 4 + 1 + i <= p.length - 1; i++) {
+            String token = p[4 + i]; // "<name>@<ip>"
+            int at = token.lastIndexOf('@');
+            String name = (at > 0) ? token.substring(0, at) : token;
+            String ip = (at > 0) ? token.substring(at + 1) : "unknown";
+            list.add(new LiveClient(name, ip, System.currentTimeMillis()));
+        }
+        liveByServer.put(key, new CopyOnWriteArrayList<>(list));
+    }
+
+    // =================== Client handling ===================
     private void handleClientRequests() {
         while (true) {
             try (Socket client = clientSocket.accept()) {
-                String clientName = null;
-                String mode = "static"; // default
+                String lbSeenRemote = String.valueOf(client.getRemoteSocketAddress());
+                String remoteIp = extractIp(lbSeenRemote);
 
                 client.setSoTimeout(1000);
                 BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
                 PrintWriter out = new PrintWriter(client.getOutputStream(), true);
 
+                String name = null;
+                String mode = defaultMode;
                 String line = null;
-                try {
-                    line = in.readLine();
-                } catch (IOException ignore) { /* timeout or no hello */ }
-
+                try { line = in.readLine(); } catch (IOException ignore) {}
                 if (line != null && line.toUpperCase().startsWith("HELLO")) {
                     String[] parts = line.trim().split("\\s+");
-                    if (parts.length >= 2) clientName = parts[1];
+                    if (parts.length >= 2) name = parts[1];
                     if (parts.length >= 3) mode = parts[2].toLowerCase(Locale.ROOT);
                 }
-                if (clientName == null || clientName.isEmpty()) {
-                    clientName = "Client-" + clientIdCounter.getAndIncrement();
+                if (name == null || name.isEmpty()) {
+                    name = "Client-" + clientIdCounter.getAndIncrement();
                 }
 
-                ServerInfo server = "dynamic".equalsIgnoreCase(mode) ? selectServerDynamic() : selectServerStatic();
-                if (server != null) {
-                    out.println(server.address + ":" + server.port);
-                    System.out.println("Client '" + clientName + "' (" + mode + ") -> " + server);
-                } else {
+                // Bans
+                if (bannedIps.contains(remoteIp) || bannedNames.contains(name)) {
                     out.println("NO_SERVER_AVAILABLE");
-                    System.out.println("No server available for client '" + clientName + "'");
+                    System.out.println("Denied client '" + name + "' from " + remoteIp + " (banned).");
+                    continue;
                 }
+
+                ServerInfo chosen = "dynamic".equalsIgnoreCase(mode) ? selectServerDynamic() : selectServerStatic();
+                if (chosen == null) {
+                    out.println("NO_SERVER_AVAILABLE");
+                    System.out.println("No server available for client '" + name + "'");
+                    continue;
+                }
+                out.println(chosen.address + ":" + chosen.port);
+                System.out.println("Client '" + name + "' (" + mode + ") -> " + chosen);
+
+                ClientRecord rec = new ClientRecord(name, mode, System.currentTimeMillis(), chosen, lbSeenRemote);
+                assignedByServer.computeIfAbsent(chosen, k -> new CopyOnWriteArrayList<>()).add(rec);
+                recentAssignments.addLast(rec);
+                while (recentAssignments.size() > MAX_RECENT) recentAssignments.pollFirst();
+
             } catch (Exception ex) {
                 System.out.println("Error processing client: " + ex.getMessage());
             }
         }
     }
 
+    private String extractIp(String remote) {
+        // formats like "/127.0.0.1:54321"
+        int slash = remote.indexOf('/');
+        int colon = remote.lastIndexOf(':');
+        if (slash >= 0 && colon > slash) return remote.substring(slash + 1, colon);
+        colon = remote.indexOf(':');
+        if (colon > 0) return remote.substring(0, colon);
+        return remote;
+    }
+
+    // =================== Selection ===================
     private ServerInfo selectServerStatic() {
-        synchronized (servers) {
-            int n = servers.size();
-            if (n == 0) {
-                System.out.println("No servers are currently registered.");
-                return null;
-            }
-            int idx = Math.floorMod(roundRobinIndex.getAndIncrement(), n);
-            return servers.get(idx);
+        List<ServerInfo> candidates = getSchedulableServers();
+        if (candidates.isEmpty()) return null;
+        // if we have weights, run RR over 'weightedList' but filter at selection time
+        for (int tries = 0; tries < weightedList.size() * 2; tries++) {
+            int idx = Math.floorMod(rrIndex.getAndIncrement(), Math.max(weightedList.size(), 1));
+            ServerInfo s = weightedList.isEmpty() ? candidates.get(idx % candidates.size()) : weightedList.get(idx);
+            if (isSchedulableNow(s)) return s;
         }
+        // fallback: first schedulable
+        for (ServerInfo s : candidates) if (isSchedulableNow(s)) return s;
+        return null;
     }
 
     private ServerInfo selectServerDynamic() {
-        ServerInfo best = null;
-        long bestT = Long.MAX_VALUE;
-        synchronized (servers) {
-            if (servers.isEmpty()) {
-                System.out.println("No servers are currently registered.");
-                return null;
-            }
-            for (ServerInfo s : servers) {
-                Long t = rtts.get(s);
-                if (t != null && t < bestT) {
-                    bestT = t;
-                    best = s;
-                }
-            }
+        List<ServerInfo> candidates = getSchedulableServers();
+        if (candidates.isEmpty()) return null;
+        ServerInfo best = null; long bestT = Long.MAX_VALUE;
+        for (ServerInfo s : candidates) {
+            if (!isSchedulableNow(s)) continue;
+            Long t = rtts.get(s);
+            if (t != null && t < bestT) { bestT = t; best = s; }
         }
-        return best != null ? best : selectServerStatic();
+        if (best != null) return best;
+        return selectServerStatic();
     }
 
+    private List<ServerInfo> getSchedulableServers() {
+        List<ServerInfo> snap;
+        synchronized (servers) { snap = new ArrayList<>(servers); }
+        snap.removeIf(drained::contains);
+        return snap;
+    }
+
+    private boolean isSchedulableNow(ServerInfo s) {
+        if (drained.contains(s)) return false;
+        if (maxPerServer == Integer.MAX_VALUE) return true;
+        int live = liveByServer.getOrDefault(s, new CopyOnWriteArrayList<>()).size();
+        return live < maxPerServer;
+    }
+
+    // =================== RTT refresher ===================
     private void startRttRefresher() {
         rttScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "LB-RTT-Refresher");
-            t.setDaemon(true);
-            return t;
+            Thread t = new Thread(r, "LB-RTT"); t.setDaemon(true); return t;
         });
         rttScheduler.scheduleAtFixedRate(() -> {
-            List<ServerInfo> snapshot;
-            synchronized (servers) {
-                snapshot = new ArrayList<>(servers);
-            }
-            snapshot.parallelStream().forEach(s -> {
-                long t = pingServer(s, 300);
-                if (t >= 0) {
-                    rtts.put(s, t);
-                }
+            List<ServerInfo> snap;
+            synchronized (servers) { snap = new ArrayList<>(servers); }
+            snap.parallelStream().forEach(s -> {
+                long t = pingServer(s, Math.max(200, pingIntervalMs / 2));
+                if (t >= 0) rtts.put(s, t);
             });
-        }, 0, 1, TimeUnit.SECONDS);
+        }, 0, pingIntervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    private void setPingInterval(int ms) {
+        pingIntervalMs = Math.max(200, ms);
+        // restart scheduler
+        rttScheduler.shutdownNow();
+        startRttRefresher();
     }
 
     private long pingServer(ServerInfo s, int timeoutMs) {
@@ -172,6 +445,63 @@ public class LoadBalancer {
         return -1;
     }
 
+    // =================== Helpers ===================
+    private void rebuildWeighted() {
+        List<ServerInfo> base;
+        synchronized (servers) { base = new ArrayList<>(servers); }
+        List<ServerInfo> w = new ArrayList<>();
+        for (ServerInfo s : base) {
+            int times = Math.max(1, weights.getOrDefault(s, 1));
+            for (int i = 0; i < times; i++) w.add(s);
+        }
+        weightedList = new CopyOnWriteArrayList<>(w);
+    }
+
+    private ServerInfo parseServer(String hp) {
+        String[] a = hp.split(":");
+        if (a.length != 2) throw new IllegalArgumentException("host:port required");
+        return new ServerInfo(a[0], Integer.parseInt(a[1]));
+    }
+
+    private void setWeight(ServerInfo s, int w) {
+        if (w < 1) w = 1;
+        if (!servers.contains(s)) { System.out.println("No such server registered: " + s); return; }
+        weights.put(s, w);
+        rebuildWeighted();
+        System.out.println("Weight set: " + s + " -> " + w);
+    }
+
+    private void removeServer(ServerInfo s) {
+        synchronized (servers) { servers.remove(s); }
+        weights.remove(s);
+        drained.remove(s);
+        liveByServer.remove(s);
+        assignedByServer.remove(s);
+        rebuildWeighted();
+        System.out.println("Removed server: " + s);
+    }
+
+    private void drain(ServerInfo s) {
+        if (!servers.contains(s)) { System.out.println("No such server: " + s); return; }
+        drained.add(s);
+        System.out.println("Drained: " + s);
+    }
+
+    private void undrain(ServerInfo s) {
+        drained.remove(s);
+        System.out.println("Undrained: " + s);
+    }
+
+    private void drainAll() {
+        synchronized (servers) { drained.addAll(servers); }
+        System.out.println("All servers drained.");
+    }
+
+    private void undrainAll() {
+        drained.clear();
+        System.out.println("All servers undrained.");
+    }
+
     public static void main(String[] args) {
         try {
             LoadBalancer lb = new LoadBalancer();
@@ -181,14 +511,10 @@ public class LoadBalancer {
         }
     }
 
+    // =================== Types ===================
     static class ServerInfo {
-        final String address;
-        final int port;
-
-        ServerInfo(String addr, int port) {
-            this.address = addr;
-            this.port = port;
-        }
+        final String address; final int port;
+        ServerInfo(String addr, int port) { this.address = addr; this.port = port; }
         @Override public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof ServerInfo)) return false;
@@ -197,5 +523,19 @@ public class LoadBalancer {
         }
         @Override public int hashCode() { return Objects.hash(address, port); }
         @Override public String toString() { return address + ":" + port; }
+    }
+
+    static class ClientRecord {
+        final String clientName, mode, lbSeenRemote;
+        final long assignedAt;
+        final ServerInfo server;
+        ClientRecord(String clientName, String mode, long assignedAt, ServerInfo server, String lbSeenRemote) {
+            this.clientName = clientName; this.mode = mode; this.assignedAt = assignedAt; this.server = server; this.lbSeenRemote = lbSeenRemote;
+        }
+    }
+
+    static class LiveClient {
+        final String name, ip; final long reportedAt;
+        LiveClient(String name, String ip, long ts) { this.name = name; this.ip = ip; this.reportedAt = ts; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,23 +1,53 @@
-1- Start the LoadBalancer class from preferred IDE.
+Networks3334 — Load Balancer, Server, Client
 
-2- Start the Server class from preferred IDE.
+Overview
+- LoadBalancer (TCP 11114 for clients, TCP 11115 for server registrations)
+- Server (TCP 11112 for commands; UDP 11113 for streaming)
+- Client (connects to LoadBalancer, then to a selected Server)
 
-3- Start the Client instance and the preferred commands may be executed as
+How load balancing works
+- Static (default): round‑robin assignment across all registered servers.
+- Dynamic: the LoadBalancer pings each server (sending "ping", expects "pong") and selects the one with the lowest measured latency. If no server replies, it falls back to static.
 
------Commands-----
+Run order
+1) Start the LoadBalancer class from your IDE (or java LoadBalancer). You should see: "Load Balancer running on ports 11114 and 11115".
+2) Start one or more Server instances from your IDE (or java Server). Each server automatically registers to the LoadBalancer at localhost:11115 and listens on TCP 11112. Console shows: "Successfully registered with Load Balancer." and "Server listening on port: 11112".
+   - Note: The sample Server uses fixed ports. To run multiple servers on one machine, change PORT/UDP_PORT in Server.java or run them on different hosts.
+3) Start Client instances. The client first contacts the LoadBalancer, then connects to the assigned Server.
 
--pwd to the similar use of pwd command in UNIX systems
+Client usage (name and mode)
+- Mode controls whether the LoadBalancer assigns the server statically or dynamically.
+- Name is a human‑readable ID shown on the LoadBalancer and Server logs.
 
--ls to the similar use of ls command in UNIX systems
+Syntax:
+  java Client [--name NAME | -n NAME] [--mode static|dynamic | -m static|dynamic]
 
--sendfile %filename%
+Defaults:
+- If --name is omitted, a unique name like "Client-<8chars>" is auto‑generated.
+- If --mode is omitted or not "dynamic", the client uses static mode by default.
 
--time for server time
+Examples
+- Static (default):
+  java Client -n Alice -m static
+- Dynamic (lowest latency):
+  java Client --name Bob --mode dynamic
+- Let the client auto‑name in dynamic mode:
+  java Client -m dynamic
 
--compute %int% for keeping the server busy for %int% seconds
+What you should see
+- LoadBalancer: "Client 'Alice' (dynamic) directed to: <ip>:11112".
+- Server: on connect, you’ll see "Client identified as: Alice from <remote>" and the server replies "Hello, Alice!" after the client sends the initial hello.
 
--stream for non-stop 1KB data stream (kept for 1 minutes of max stream time)
+Available client commands (after connection to a Server)
+- pwd    — current working directory on the server
+- ls     — list files
+- sendfile <filename>
+- time   — server time
+- compute <seconds> — keep server busy for N seconds
+- stream — start UDP streaming (1 KB packets, limited duration)
+- cancel — stop streaming
+- quit   — disconnect the client
 
--cancel for stopping the listening from the server.
-
-Multiple instances of Clients can be run which will be connected via next possible sub connections done with LoadBalancer.
+Notes
+- The Server registers to a LoadBalancer on localhost. To use a remote LoadBalancer, adjust LOAD_BALANCER_HOST in Server.java.
+- Dynamic mode relies on the Server replying "pong" to "ping" (already implemented).

--- a/Server.java
+++ b/Server.java
@@ -1,41 +1,75 @@
 import java.io.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Date;
 
 public class Server {
-    private static final int PORT = 11112;
-    private static final int UDP_PORT = 11113;
-    private static final int LOAD_BALANCER_REGISTRATION_PORT = 11115;
-    private static final String LOAD_BALANCER_HOST = "localhost";
-    private static DatagramSocket udpSocket;
-    private static volatile boolean streaming = false;
+    // Defaults (can be overridden with CLI args)
+    private static final String DEFAULT_LB_HOST = "localhost";
+    private static final int DEFAULT_LB_REG_PORT = 11115;
+
+    private static DatagramSocket udpSocket; // source socket for UDP streaming (server -> client)
 
     public static void main(String[] args) throws IOException {
-        registerWithLoadBalancer();
-        udpSocket = new DatagramSocket(UDP_PORT);
-        ServerSocket serverSocket = new ServerSocket(PORT);
-        System.out.println("Server listening on port: " + PORT);
+        // ---- Parse CLI args ----
+        int tcpPort = 0;       // 0 => ephemeral, allows multiple instances
+        int udpPort = 0;       // 0 => ephemeral, allows multiple instances
+        String lbHost = DEFAULT_LB_HOST;
+        int lbRegPort = DEFAULT_LB_REG_PORT;
 
+        for (int i = 0; i < args.length; i++) {
+            String a = args[i];
+            if (("--port".equalsIgnoreCase(a) || "-p".equalsIgnoreCase(a)) && i + 1 < args.length) {
+                tcpPort = Integer.parseInt(args[++i]);
+            } else if (("--udp-port".equalsIgnoreCase(a) || "-u".equalsIgnoreCase(a)) && i + 1 < args.length) {
+                udpPort = Integer.parseInt(args[++i]);
+            } else if ("--lb-host".equalsIgnoreCase(a) && i + 1 < args.length) {
+                lbHost = args[++i];
+            } else if (("--lb-port".equalsIgnoreCase(a) || "--lb-reg-port".equalsIgnoreCase(a)) && i + 1 < args.length) {
+                lbRegPort = Integer.parseInt(args[++i]);
+            }
+        }
+
+        // ---- Bind sockets (TCP first so we know the actual port to register) ----
+        ServerSocket serverSocket = new ServerSocket(tcpPort);
+        serverSocket.setReuseAddress(true);
+        tcpPort = serverSocket.getLocalPort(); // get the real port if ephemeral
+
+        udpSocket = new DatagramSocket(udpPort);
+        udpSocket.setReuseAddress(true);
+        udpPort = udpSocket.getLocalPort();
+
+        // ---- Register with LB using the real TCP port ----
+        registerWithLoadBalancer(lbHost, lbRegPort, tcpPort);
+
+        System.out.println("Server listening on TCP " + tcpPort + " and UDP " + udpPort
+                + " (LB " + lbHost + ":" + lbRegPort + ")");
+
+        // ---- Accept loop ----
         while (true) {
             try {
                 Socket clientSocket = serverSocket.accept();
-                System.out.println("Accepted connection from client: " + clientSocket.getRemoteSocketAddress());
-                ClientHandler handler = new ClientHandler(clientSocket);
-                new Thread(handler).start();
+                // No noisy "Accepted ..." log; we'll log after a real hello
+                new Thread(new ClientHandler(clientSocket), "Srv-Client-" + clientSocket.getPort()).start();
             } catch (IOException e) {
-                System.out.println("Connection Error: " + e.getMessage());
+                System.out.println("Accept error: " + e.getMessage());
             }
         }
     }
 
-    private static void registerWithLoadBalancer() {
-        try (Socket socket = new Socket(LOAD_BALANCER_HOST, LOAD_BALANCER_REGISTRATION_PORT);
+    private static void registerWithLoadBalancer(String lbHost, int lbRegPort, int tcpPort) {
+        try (Socket socket = new Socket(lbHost, lbRegPort);
              PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
              BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
-            out.println("!join -v dynamic " + PORT);
+
+            // flexible format; LB parses the last token as the port
+            out.println("!join -v dynamic " + tcpPort);
             String response = in.readLine();
             if ("!ack".equals(response)) {
-                System.out.println("Successfully registered with Load Balancer.");
+                System.out.println("Registered with Load Balancer on TCP port " + tcpPort);
+            } else {
+                System.out.println("Load Balancer did not ack registration (response=" + response + ")");
             }
         } catch (IOException e) {
             System.out.println("Could not connect to Load Balancer: " + e.getMessage());
@@ -44,57 +78,141 @@ public class Server {
 
     private static class ClientHandler implements Runnable {
         private final Socket clientSocket;
+        private String clientName = "";
+        private InetAddress clientUdpAddr = null;
+        private int clientUdpPort = -1;
 
-        public ClientHandler(Socket socket) {
-            this.clientSocket = socket;
-        }
+        private volatile boolean streaming = false;
+        private Thread streamThread = null;
+
+        ClientHandler(Socket socket) { this.clientSocket = socket; }
 
         public void run() {
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
-                 PrintWriter out = new PrintWriter(clientSocket.getOutputStream(), true)) {
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream(), StandardCharsets.UTF_8));
+                 PrintWriter out = new PrintWriter(new OutputStreamWriter(clientSocket.getOutputStream(), StandardCharsets.UTF_8), true)) {
+
                 String inputLine;
                 while ((inputLine = in.readLine()) != null) {
-                    String[] commands = inputLine.split(" ");
-                    switch (commands[0].toLowerCase()) {
-                        case "time": out.println(new Date()); break;
-                        case "ls": out.println(ls()); break;
-                        case "pwd": out.println(pwd()); break;
-                        case "sendfile": handleSendFile(commands, clientSocket); break;
-                        case "compute": handleCompute(commands, out); break;
-                        case "quit": clientSocket.close(); return;
-                        case "stream": streaming = true; startStreaming(clientSocket.getInetAddress()); break;
-                        case "cancel": streaming = false; System.out.println("Streaming stopped by cancel command."); break;
-                        default: out.println("Unknown command"); break;
+                    String[] commands = inputLine.trim().split("\\s+");
+                    if (commands.length == 0) continue;
+                    String cmd = commands[0].toLowerCase();
+
+                    switch (cmd) {
+                        case "hello":
+                            if (commands.length > 1) {
+                                clientName = commands[1];
+                                System.out.println("Client identified as: " + clientName + " from " + clientSocket.getRemoteSocketAddress());
+                                out.println("Hello, " + clientName + "!");
+                            } else {
+                                out.println("Hello received without name. Use: hello <name>");
+                            }
+                            break;
+
+                        case "udp":
+                            if (commands.length > 1) {
+                                try {
+                                    clientUdpPort = Integer.parseInt(commands[1]);
+                                    clientUdpAddr = clientSocket.getInetAddress();
+                                    out.println("UDP registered: " + clientUdpAddr.getHostAddress() + ":" + clientUdpPort);
+                                } catch (NumberFormatException e) {
+                                    out.println("Bad UDP port");
+                                }
+                            } else {
+                                out.println("Usage: udp <port>");
+                            }
+                            break;
+
+                        case "stream":
+                            if (clientUdpAddr == null || clientUdpPort <= 0) {
+                                out.println("No UDP registration. Use: udp <port> first.");
+                                break;
+                            }
+                            if (streaming) {
+                                out.println("Already streaming.");
+                                break;
+                            }
+                            streaming = true;
+                            out.println("Streaming started to " + clientUdpAddr.getHostAddress() + ":" + clientUdpPort);
+                            startStreamingInBackground(out);
+                            break;
+
+                        case "cancel":
+                            if (streaming) {
+                                streaming = false;
+                                if (streamThread != null) streamThread.interrupt();
+                                out.println("Streaming stop requested.");
+                            } else {
+                                out.println("Not streaming.");
+                            }
+                            break;
+
+                        case "ping":
+                            out.println("pong"); // LB RTT checks hit this; keep quiet in logs
+                            break;
+
+                        case "time":
+                            out.println(new Date());
+                            break;
+
+                        case "ls":
+                            out.println(ls());
+                            break;
+
+                        case "pwd":
+                            out.println(pwd());
+                            break;
+
+                        case "sendfile":
+                            handleSendFile(commands, out);
+                            break;
+
+                        case "compute":
+                            handleCompute(commands, out);
+                            break;
+
+                        case "quit":
+                            out.println("Bye.");
+                            clientSocket.close();
+                            return;
+
+                        default:
+                            out.println("Unknown command");
+                            break;
                     }
                 }
             } catch (IOException e) {
-                System.out.println("Error handling client: " + e.getMessage());
+                System.out.println("Client handler IO error: " + e.getMessage());
             } finally {
-                try {
-                    clientSocket.close();
-                } catch (IOException e) {
-                    System.out.println("Could not close a socket: " + e.getMessage());
-                }
+                try { clientSocket.close(); } catch (IOException ignore) {}
+                streaming = false;
+                if (streamThread != null) streamThread.interrupt();
             }
         }
 
-        private void startStreaming(InetAddress address) {
-            byte[] buffer = new byte[1024];
-            DatagramPacket packet = new DatagramPacket(buffer, buffer.length, address, UDP_PORT);
-            try {
-                int i = 0;
-                while (streaming) {
-                    udpSocket.send(packet);
-                    System.out.println("Streaming data...");
-                    Thread.sleep(2000);
-                    if (i > 30) streaming = false;
-                    i++;
+        private void startStreamingInBackground(PrintWriter out) {
+            streamThread = new Thread(() -> {
+                try {
+                    int i = 0;
+                    while (streaming && i++ < 30) {
+                        byte[] buffer = ("tick " + System.currentTimeMillis()).getBytes(StandardCharsets.UTF_8);
+                        DatagramPacket packet = new DatagramPacket(buffer, buffer.length, clientUdpAddr, clientUdpPort);
+                        // synchronize to avoid concurrent sends on a shared DatagramSocket
+                        synchronized (udpSocket) {
+                            udpSocket.send(packet);
+                        }
+                        Thread.sleep(2000);
+                    }
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt(); // normal on cancel
+                } catch (IOException e) {
+                    System.out.println("Streaming error: " + e.getMessage());
+                } finally {
+                    streaming = false;
+                    try { out.println("Streaming ended."); } catch (Exception ignore) {}
                 }
-                System.out.println("Exiting streaming mode.");
-            } catch (IOException | InterruptedException e) {
-                System.out.println("Streaming interrupted: " + e.getMessage());
-                Thread.currentThread().interrupt();
-            }
+            }, "Stream-" + (clientName.isEmpty() ? String.valueOf(clientSocket.getPort()) : clientName));
+            streamThread.setDaemon(true);
+            streamThread.start();
         }
 
         private static String ls() {
@@ -113,45 +231,53 @@ public class Server {
             return System.getProperty("user.dir");
         }
 
-        private static void handleSendFile(String[] commands, Socket clientSocket) throws IOException {
-            BufferedOutputStream bos = new BufferedOutputStream(clientSocket.getOutputStream());
-            boolean verbose = commands.length > 2 && "-v".equals(commands[1]);
-            String fileName = verbose ? commands[2] : commands[1];
-            sendFile(fileName, bos, verbose);
-        }
+        // Line-oriented Base64 transfer to keep stream text-friendly
+        private void handleSendFile(String[] commands, PrintWriter out) {
+            boolean verbose = commands.length > 2 && "-v".equalsIgnoreCase(commands[1]);
+            String fileName = verbose ? commands[2] : (commands.length > 1 ? commands[1] : null);
 
-        private static void sendFile(String fileName, BufferedOutputStream bos, boolean verbose) throws IOException {
-            File file = new File(fileName);
-            if (!file.exists()) {
-                PrintWriter out = new PrintWriter(bos, true);
-                out.println("File not found");
+            if (fileName == null) {
+                out.println("Usage: sendfile [-v] <filename>");
                 return;
             }
 
-            try (FileInputStream fis = new FileInputStream(file);
-                 BufferedInputStream bis = new BufferedInputStream(fis)) {
-                byte[] bytes = new byte[4096];
-                int count;
-                while ((count = bis.read(bytes)) > 0) {
-                    bos.write(bytes, 0, count);
-                    if (verbose) {
-                        System.out.println("Sent " + count + " bytes of " + fileName);
-                    }
-                }
-                bos.flush();
-            } catch (IOException e) {
-                System.out.println("Error sending file: " + e.getMessage());
+            File file = new File(fileName);
+            if (!file.exists() || !file.isFile()) {
+                out.println("ERROR File not found");
+                return;
             }
 
-            PrintWriter out = new PrintWriter(bos, true);
-            out.println("EOF");
+            out.println("FILE " + file.getName() + " " + file.length());
+            Base64.Encoder encoder = Base64.getEncoder();
+
+            try (InputStream fis = new BufferedInputStream(new FileInputStream(file))) {
+                byte[] buf = new byte[4096];
+                int n;
+                while ((n = fis.read(buf)) >= 0) {
+                    if (n == 0) continue;
+                    String b64 = encoder.encodeToString(n == buf.length ? buf : java.util.Arrays.copyOf(buf, n));
+                    out.println(b64);
+                    if (verbose) {
+                        System.out.println("Sent chunk (" + n + " bytes) of " + file.getName());
+                    }
+                }
+            } catch (IOException e) {
+                out.println("ERROR Sending file: " + e.getMessage());
+                return;
+            }
+
+            out.println("ENDFILE");
         }
 
         private static void handleCompute(String[] commands, PrintWriter out) {
             if (commands.length > 1) {
-                int seconds = Integer.parseInt(commands[1]);
-                compute(seconds);
-                out.println("Computed for " + seconds + " seconds");
+                try {
+                    int seconds = Integer.parseInt(commands[1]);
+                    compute(seconds);
+                    out.println("Computed for " + seconds + " seconds");
+                } catch (NumberFormatException e) {
+                    out.println("Bad duration");
+                }
             } else {
                 out.println("Duration not specified");
             }
@@ -168,4 +294,3 @@ public class Server {
         }
     }
 }
-//Author Mert.


### PR DESCRIPTION
# Java TCP/UDP Load Balancer Demo

A minimal, production-inspired load balancer with **static round-robin** and **dynamic (RTT-based)** server selection, **multi-instance servers**, **UDP “streaming” side-channel**, **Base64 file transfer**, and a built-in **admin console** to observe and control the cluster live.

---

## Table of Contents

- [Architecture](#architecture)
- [Features](#features)
- [Ports & Protocols](#ports--protocols)
- [Build](#build)
- [Run](#run)
  - [Load Balancer](#load-balancer)
  - [Server (multi-instance)](#server-multi-instance)
  - [Client](#client)
- [Admin Console (LB)](#admin-console-lb)
- [Wire Protocols](#wire-protocols)
  - [Server ↔ LB](#server--lb)
  - [Client ↔ LB](#client--lb)
  - [Client ↔ Server (TCP)](#client--server-tcp)
  - [Server → Client (UDP)](#server--client-udp)
- [Scheduling Logic](#scheduling-logic)
- [Examples](#examples)
- [Troubleshooting](#troubleshooting)
- [Security Notes](#security-notes)
- [Extending](#extending)

---

## Architecture

```
+-----------+        +------------------+        +-------------------------+
|  Client   | <----> |  Load Balancer   | <----> |  Server (N instances)   |
| (TCP+UDP) |  TCP   |  (TCP admin,     |  TCP   |  TCP cmd, UDP streaming |
|           |        |  TCP reg/pings)  |        |  + periodic LB reports  |
+-----------+        +------------------+        +-------------------------+
         ^                       ^                             |
         |  UDP ticks            |                             | UDP
         +-----------------------+-----------------------------+
```

- **Client ↔ LB (TCP 11114):** client asks for a backend; LB replies with `host:port`.
- **Server ↔ LB (TCP 11115):** server registers (`!join`) and periodically reports live clients (`!report`).
- **Client ↔ Server (TCP):** line-based command protocol (`hello`, `ping`, `sendfile`, `stream`, …).
- **Server → Client (UDP):** optional periodic “tick” packets; client listens and prints.

---

## Features

- **Static RR** with **weights**, **drain**/undrain, **manual removal**.
- **Dynamic selection** via **background RTT probes** (configurable interval).
- **Live client visibility** (servers report current sessions to LB).
- **Access controls:** ban by client name or IP.
- **Max connections/server** (uses server live reports).
- **Multi-instance servers** on the same host (ephemeral ports by default).
- **Responsive streaming cancel** (background thread, immediate `cancel`).
- **Text-safe file transfer** (Base64 framed).

---

## Ports & Protocols

| Component | Purpose                       | Default Port |
|----------:|-------------------------------|:------------:|
| LB        | Client handshakes             | **11114/TCP** |
| LB        | Server register & reports     | **11115/TCP** |
| Server    | Client commands               | **ephemeral (0)** or custom (e.g., 11112/TCP) |
| Server    | UDP streaming source          | **ephemeral (0)** or custom (e.g., 11113/UDP) |
| Client    | UDP listening port            | **ephemeral (auto)** |

> Servers advertise the **actual bound TCP port** to the LB, so you can run many in parallel.

---

## Build

Requires **JDK 8+**.

```bash
javac LoadBalancer.java Server.java Client.java
```

---

## Run

### Load Balancer

```bash
java LoadBalancer
```

Interactive admin console is available in the same terminal; type `help`.

---

### Server (multi-instance)

Run one or many:

```bash
# Ephemeral TCP/UDP ports (recommended for many instances)
java Server

# Explicit ports (optional)
java Server --port 11112 --udp-port 11113 --lb-host localhost --lb-port 11115

# Short flags:
java Server -p 0 -u 0
```

Each server registers with the LB using its **real TCP port**.

---

### Client

```bash
# Static or dynamic selection; name is optional
java Client --mode dynamic --name Alice
java Client -m static -n Bob
```

Interactive commands after connected (type into client’s stdin):

```
hello Alice
udp 54321                # auto-sent by client using its UDP socket; you can resend
stream                   # start UDP ticks
cancel                   # stop streaming (immediate)
ping | time | ls | pwd   # utility commands
sendfile README.md       # Base64 framed transfer
compute 3                # sleep 3s to simulate work
quit
```

---

## Admin Console (LB)

Type these in the **LB terminal**:

- **Cluster views**
  - `servers` — list servers with RTT, weight, drain flag, live client count
  - `live` — live clients per server (reported)
  - `clients` / `recent` — LB’s recent assignment history
  - `status` — `servers` + `live`
- **Capacity / policy**
  - `set ping <ms>` — RTT probe interval (default 1000ms)
  - `set maxconn <N>` — cap live clients per server
  - `mode default <static|dynamic>` — default when client omits mode
- **Weights & draining**
  - `setweight <host:port> <N>` — weighted RR
  - `weights` — show weights
  - `drain <host:port|all>` / `undrain <host:port|all>` / `drained`
- **Access control**
  - `ban ip <x>` / `unban ip <x>`
  - `ban name <x>` / `unban name <x>`
  - `bans`
- **Maintenance**
  - `remove <host:port>` — unregister
  - `clear` — clear assignment history
  - `help`

> **Note:** “live” lists are **actual connected clients** (reported by servers), while “recent” shows whom the LB **directed** to which server.

---

## Wire Protocols

### Server ↔ LB

- **Register:**  
  `!join -v dynamic <tcpPort>` → LB replies `!ack`

- **Report (every ~2s):**  
  `!report <tcpPort> clients <N> <name>@<ip> ...`  
  LB updates its live view and uses it for `maxconn` and console.

### Client ↔ LB

- **Handshake:**  
  `HELLO <name> <mode>` where `<mode>` ∈ `{static,dynamic}`  
  (name optional; LB will assign `Client-<id>` if missing)

- **Reply:**  
  `<serverHost>:<serverPort>` or `NO_SERVER_AVAILABLE`

### Client ↔ Server (TCP)

Line-based commands:

- `hello <name>` → `Hello, <name>!`
- `udp <port>` — register client’s UDP port for streaming
- `stream` / `cancel`
- `ping` → `pong`
- `time` → server time
- `ls`, `pwd`
- `compute <seconds>`
- `sendfile [-v] <filename>` — **framed, Base64**
  - Header: `FILE <name> <sizeBytes>`
  - Content: multiple Base64 lines
  - Terminator: `ENDFILE`
- `quit`

### Server → Client (UDP)

- Payload: simple UTF-8 `"tick <millis>"` every ~2s while streaming.

---

## Scheduling Logic

1. **Candidate set** = registered servers **minus** any **drained** servers and any server at or above **maxconn** (uses live reports).
2. **Dynamic mode:** pick the **lowest RTT** among candidates (background cache).
3. **Static mode:** **weighted** round-robin across candidates using `setweight`.
4. If dynamic yields none (no RTT yet), fallback to static.

---

## Examples

**Start cluster**
```bash
# Terminal 1 (LB)
java LoadBalancer

# Terminal 2..N (multiple servers)
java Server
java Server
java Server -p 0 -u 0
```

**Connect clients**
```bash
java Client -n Alice -m dynamic
java Client -n Bob   -m static
```

**In the LB console**
```
servers
live
set maxconn 1
status
drain 127.0.0.1:12345
setweight 127.0.0.1:23456 5
ban name Alice
bans
```

---

## Troubleshooting

- **Server logs “Accepted connection …” too often**  
  That’s the LB’s RTT pinger. It connects briefly and sends `ping`; servers reply `pong` without verbose logging. This is expected.

- **`cancel` isn’t immediate**  
  Streaming runs in a **background thread** and checks a `volatile` flag; `cancel` interrupts the thread. If you customized the code and call `stream` on the **same reader thread**, move it back to a background thread.

- **No UDP ticks on client**  
  Ensure the client **sent** `udp <port>` (the provided client auto-registers its UDP port). Firewalls may need UDP allowances.

- **Multiple servers on same host**  
  Use **ephemeral** ports (`-p 0 -u 0`) or unique explicit ports. Each server registers its **real TCP port**.

- **File transfer dumps gibberish in console**  
  The protocol is **framed & Base64** to stay line-safe. The client saves received data to `received_<name>` and logs bytes.

---

## Security Notes

- **No auth**: anyone can register a server or request routing; use **bans**, **drain**, and run on a **trusted network** only.
- **File serving is local-filesystem** access on the server process; sandbox accordingly.
- **No TLS**: use stunnel/SSH tunnel or embed TLS if used beyond a lab.

---

## Extending

- **Heartbeats & eviction**: prune servers missing reports for N intervals.
- **Health checks**: track success/failure rates per server.
- **Sticky sessions**: consistent hashing by client name/IP.
- **Graceful drain**: server rejects new connections but keeps existing until idle.
- **JSON admin API**: expose read-only views and actions over HTTP.

---
